### PR TITLE
Refactor dfsData and bfsData APIs & Add DeleteHis

### DIFF
--- a/webapp/index.js
+++ b/webapp/index.js
@@ -24,27 +24,71 @@ app.get("/", (req, res) => {
   res.send("Hello World");
 })
 
-app.get('/history', (req, res)=>{
+app.get('/history', (req, res)=> {
   res.send(req.cookies.searchingHistory);
 });
 
-app.get("/dfsData", (req, res) => {
+app.delete('/history', (req, res) => {
+  res.cookie("searchingHistory", "[]"); // Reset Cookie
+  res.status(204).end();
+});
+
+app.post("/dfsData", (req, res) => {
+
+  if (req.body.url == null) {
+    return res.status(404).send('Please Enter the URL.');
+  }
+
   let currentCookie = req.cookies.searchingHistory;
-  currentCookie =  addSearchingHistoryInCurrentCookie(req.cookies.searchingHistory, "get DFS data!");
+
+  const depth = req.body.depth;
+  const algorithm = 'dfs';
+  const url = req.body.url;
+  const keyword = req.body.keyword;
+
+  const searchResult = {
+    "algorithm": algorithm,
+    "url": url,
+    "depth": depth,
+    "keyword": keyword
+  }
+
+  currentCookie =  addSearchingHistoryInCurrentCookie(req.cookies.searchingHistory, searchResult);
+
+  // console.log("Search for: " + JSON.stringify(searchResult));
 
   res.cookie("searchingHistory", currentCookie);
 
-	res.send(dfsData);
+	return res.status(201).send(dfsData); // Hard-coded mock data
 })
 
-app.get("/bfsData", (req, res) => {
+app.post("/bfsData", (req, res) => {
+
+  if (req.body.url == null) {
+    return res.status(404).send('Please Enter the URL.');
+  }
 
   let currentCookie = req.cookies.searchingHistory;
-  currentCookie =  addSearchingHistoryInCurrentCookie(req.cookies.searchingHistory, "get BFS data!");
+
+  const depth = req.body.depth;
+  const algorithm = 'bfs';
+  const url = req.body.url;
+  const keyword = req.body.keyword;
+
+  const searchResult = {
+    "algorithm": algorithm,
+    "url": url,
+    "depth": depth,
+    "keyword": keyword
+  }
+
+  currentCookie =  addSearchingHistoryInCurrentCookie(req.cookies.searchingHistory, searchResult);
 
   res.cookie("searchingHistory", currentCookie);
 
-  res.send(bfsData);
+  // console.log("Search for: " + JSON.stringify(searchResult));
+
+	return res.status(201).send(dfsData); // Hard-coded mock data
 })
 
 


### PR DESCRIPTION
## Notes

- Change both APIs from `GET` to `POST`
- Write in the whole searching result to the history array
- Add response code 201 and 404 for success and failed API call
- parse the request body
- Add `DELETE` History API

## API Example

### GET `/history`
- Response a String with Status Codes `200`:
```
[{"algorithm":"dfs","url":"reddit.com","depth":"2","keyword":"
"},{"algorithm":"dfs","url":"reddit.com","depth":"2","keyword":"
"},{"algorithm":"dfs","url":"reddit.com","depth":"2","keyword":"
"},{"algorithm":"dfs","url":"reddit.com","depth":"2","keyword":"
"},{"algorithm":"bfs","url":"reddit.com","depth":"2","keyword":" "}]
```

### DELETE `/history`
- Response Status Code `204` without body

### POST `/dfsData`
- Request Body
```json
{
	"url": "reddit.com",
	"depth": "2",
	"keyword": " "
}
```
- Response Status Code `201` with [mock DFS Data](https://github.com/WeiChienHsu/Web_Crawler_CS467/blob/master/webapp/mockData/mockDFS.json)


- Write record into Cookies
```
{"algorithm":"dfs","url":"reddit.com","depth":"2","keyword":" "}
```

- Current Error Handle: Pass in a request body without **url**  parameter will get a 404 response. In UI, we should display this error message to our users.

### POST `/bfsData`
- Request Body
```json
{
	"url": "reddit.com",
	"depth": "2",
	"keyword": " "
}
```
- Response Status Code `201` with [mock BFS Data](https://github.com/WeiChienHsu/Web_Crawler_CS467/blob/master/webapp/mockData/mockBFS.json)

- Write record into Cookies
```
{"algorithm":"bfs","url":"reddit.com","depth":"2","keyword":" "}
```

- Current Error Handle: Pass in a request body without **url**  parameter will get a 404 response. In UI, we should display this error message to our users.

---

## TODO

- Add run_dfs/run_bfs in `index.js` to call the Google Cloud Function Endpoint
- Add more error handlers in POST DFS/BFS methods