### PR TITLE
Add features - Domain / Keyword

### DIFF
--- a/webapp/react-front-end/src/App.css
+++ b/webapp/react-front-end/src/App.css
@@ -6,7 +6,7 @@
 }
 
 body {
-  font-family: cursive;
+  font-family: Helvetica;
   overflow-x: hidden;
 }
 
@@ -15,7 +15,7 @@ body {
 }
 
 .logo {
-  font-family: cursive;
+  font-family: Helvetica;
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Why we add keywordFound attribute

We were discussing the implementation details of `keywords.`

This is how it described in the original project proposal:

```
As an option, the user should be able to type in a keyword that will halt the program from searching when it is discovered on a page 
(this page and keyword are not being searched for, they are merely being encountered by chance). 
This page must be highlighted in the graphical results shown to the user
```

---

### Increase the complexity of mock data

- Add "keywordFound" in the last node within mock data 

- So, I can simply to see if the node has property, 'keywordFound', to determine whether I need to assign a different color to that node. Thank you so much!

```json
{
 "url": "https://www.reddit.com/help/privacypolicy/",
 "domainName": "reddit",
 "title": "Privacy Policy - May 25, 2018 - Reddit",
 "hasKeyword": true,
 "keywordFound" : null
}
```

---

### Different Domains

Also, there is another requirement that I should implement this week. 

This is how it described in the original project proposal:

```
As a Web Frontend, it can differentiate the node color by the domain name

Nodes will be colored by domain
```

So, I gave each connected node different domain names to test if my new changes work for this requirement. 

---

## Implement the logic to D3Tree to display keywordFound node with unique color

1. Create an array to record what domain name that has been used
2. Create a Map to record the color that has been using for the specific domain
3. Create another array to record all red colors family which is similar to the color for the node with keyword
4. So, if it's the first time we see the domain name, it will get a random color by calling getRandomColor function
5. Then, record the pair of the domain and its color in the Map
6. If the domain name has been assigned a color before, it will just get the color from the map without calling getRandomColor


```js
let usedColor = ['#FF0000'];
let colorMap = new Map();

  getRandomColor = () => {
    var letters = "0123456789ABCDEF";
    var color = "#";
    for (var i = 0; i < 6; i++) {
      color += letters[Math.floor(Math.random() * 16)];
    }
    return color;
  };

  getColor = (domainName) => {

    const redFamily = ['#D0312D', '#990F02', '#E3242B', '#60100B',
                  '#541E1B', '#610C04', '#B90E0A', '#900603',
                  '#900D09', '#4E0707', '#7E2811', '#A91B0D',
                  '#420C09', '#710C04', '#5E1916', '#7A1712',
                  '#680C07', '#BC544B', '#D21404', '#9B1003']
    
    if(colorMap.has(domainName)) {
      // Used the color in the map
      return colorMap.get(domainName)
    }
    else {
      // Get a random color
      let color = this.getRandomColor();
      // Check if the color has been used or in the red family
      while(usedColor.includes(color) || redFamily.includes(color)) {
        color = this.getRandomColor();
      }

      // Add Color in the Map
      colorMap.set(domainName, color);
      return color;
    }
  }
```

---

## Implement the logic to D3Tree to assign different colors to each node based on its domain

There are three different seniors:

1. Node has children: it's not possible to have the keyword in the URL because the web crawler should be terminated before searching for the next node.

- Call getColor function
- Don't need to handle the node with keyword
- Recursively call the treeModifications function for each child

```json
{
   "url": "https://www.osu.com/help/IAMKEYWORD/",
   "domainName": "osu",
   "title": "Content Policy",
   "children" : [
     {
         "url": "https://www.osu.com/help/IAMKEYWORD/",
         "domainName": "osu",
         "title": "Content Policy",
         "children" : null
     }
   ]
}
```

2. Node has children, but it's the result of DFS, so the node should be the one with the keyword as well

- Directly assign color RED to the node and mark it as the node with keyword
- Reset the Map and used color array
- After user click the search button, it'll assign a whole new color set to the chart

```json
{
  "url": "https://www.osu.com/help/IAMKEYWORD/",
  "domainName": "osu",
  "title": "Content Policy",
  "children" : null,
  "keywordFound": true
}
```

3. Node has children, but no keyword found
   
- Since in the BFS, all the nodes in the last level would not have a child
- So, we have to check whether the node has keywordFound attribute 
- Then, determine if we need to handle this node as a special one


```js
  treeModifications = element => {
    // 1. The node which has children is not possible to be the node with keyword
    if (element.hasOwnProperty("children") && 
        element.children != null) 
    {
      element["name"] = element.domainName;
      element["nodeSvgShape"] = {
        shape: "rect",
        shapeProps: {
          width: 130,
          height: 60,
          x: 2,
          y: -40,
          fill: this.getColor(element.domainName)
        }
      };

      element.children.forEach(element => {
        this.treeModifications(element);
      });
    } 
    // 2. Each leaf node might has keyword included in BFS
    else if (element.hasOwnProperty("keywordFound") && 
             element.keywordFound == true) 
    {
      /* Assign different color to mark this node as last node */
      element["name"] = element.domainName + ' - Keyword';
      element["nodeSvgShape"] = {
        shape: "rect",
        shapeProps: {
          width: 180,
          height: 60,
          x: 2,
          y: -40,
          fill: "#FF0000"
        }
      }

      // Rest color map since the next searching will start with new colors set
      usedColor = ['#FF0000'];
      colorMap = new Map();
      return;
    }
    else 
    {
      element["name"] = element.domainName;
      element["nodeSvgShape"] = {
        shape: "rect",
        shapeProps: {
          width: 130,
          height: 60,
          x: 2,
          y: -40,
          fill: this.getColor(element.domainName)
        }
      }

      return;
    }
  };
  ```